### PR TITLE
Added cache object to node-sass-once-importer

### DIFF
--- a/packages/node-sass-once-importer/src/index.ts
+++ b/packages/node-sass-once-importer/src/index.ts
@@ -18,6 +18,8 @@ export = function onceImporter() {
 
   // cache for path resolution
   let includePathsCache: Map<string, string[]> = new Map();
+  // cache for resolvedUrls
+  let resolvedUrlsCache: Map<string, string> = new Map();
 
   return function importer(url: string, prev: string) {
     const nodeSassOptions = this.options;
@@ -33,17 +35,21 @@ export = function onceImporter() {
     // would be detected as multiple imports of the same file.
     const store = this.nodeSassOnceImporterContext.store;
     // per instance of new importer created, path resolution is shared
-    if (!includePathsCache.has(url)) {
+    if (!includePathsCache.has(nodeSassOptions.includePaths)) {
       includePathsCache.set(url, buildIncludePaths(
         nodeSassOptions.includePaths,
         prev,
       ));
     }
-    const includePaths = includePathsCache.get(url);
-    const resolvedUrl = resolveUrl(
-      url,
-      includePaths,
-    );
+    const includePaths = includePathsCache.get(nodeSassOptions.includePaths);
+
+    if (!resolvedUrlsCache.has(url)){
+      resolvedUrlsCache.set(url, resolveUrl(
+        url,
+        includePaths,
+      ));
+    }
+    const resolvedUrl = resolvedUrlsCache.get(url);
 
     if (store.has(resolvedUrl)) {
       return EMPTY_IMPORT;

--- a/packages/node-sass-once-importer/src/index.ts
+++ b/packages/node-sass-once-importer/src/index.ts
@@ -16,8 +16,6 @@ export = function onceImporter() {
     store: new Set(),
   };
 
-  // cache for path resolution
-  let includePathsCache: Map<string, string[]> = new Map();
   // cache for resolvedUrls
   let resolvedUrlsCache: Map<string, string> = new Map();
 
@@ -35,15 +33,15 @@ export = function onceImporter() {
     // would be detected as multiple imports of the same file.
     const store = this.nodeSassOnceImporterContext.store;
     // per instance of new importer created, path resolution is shared
-    if (!includePathsCache.has(nodeSassOptions.includePaths)) {
-      includePathsCache.set(url, buildIncludePaths(
-        nodeSassOptions.includePaths,
-        prev,
-      ));
-    }
-    const includePaths = includePathsCache.get(nodeSassOptions.includePaths);
 
-    if (!resolvedUrlsCache.has(url)){
+    const includePaths = buildIncludePaths(
+      nodeSassOptions.includePaths,
+      prev,
+    );
+
+    // the perf improvement here is avoiding a glob.sync call in resolveUrl
+    // if we dont need it
+    if (!resolvedUrlsCache.has(url)) {
       resolvedUrlsCache.set(url, resolveUrl(
         url,
         includePaths,


### PR DESCRIPTION
We have a very long build step, lots of files being written with a legacy & new code base.

This change speeds up file resolution for us by up to 15s on a baseline 75-80s build step.