### PR TITLE
Remove LibSass deprecation warning for css files.

### DIFF
--- a/packages/node-sass-package-importer/src/index.ts
+++ b/packages/node-sass-package-importer/src/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import {
   buildIncludePaths,
   resolvePackageUrl,
@@ -37,6 +38,14 @@ export = function packageImporter(userOptions?: IPackageImporterOptions) {
       options.packageKeys,
     );
 
-    return file ? { file: file.replace(/\.css$/, ``) } : null;
+    if (!file) {
+      return null;
+    }
+
+    if (/\.css$/.test(file)) {
+      return { contents: fs.readFileSync(file, 'utf-8') };
+    }
+
+    return { file: file.replace(/\.css$/, ``) };
   };
 };


### PR DESCRIPTION
Includes file contents instead of file path to avoid deprecation message.
See https://github.com/maoberlehner/node-sass-magic-importer/issues/181