### PR TITLE
Import from dist instead of from src

### DIFF
--- a/packages/node-sass-filter-importer/src/default-options.ts
+++ b/packages/node-sass-filter-importer/src/default-options.ts
@@ -1,4 +1,4 @@
-import { ICustomFilter } from 'css-node-extract/src/interfaces/ICustomFilter';
+import { ICustomFilter } from 'css-node-extract/dist/interfaces/ICustomFilter';
 
 export const defaultOptions: {
   customFilters?: ICustomFilter[];

--- a/packages/node-sass-filter-importer/src/index.ts
+++ b/packages/node-sass-filter-importer/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from 'node-sass-magic-importer/dist/toolbox';
 import { defaultOptions } from './default-options';
 
-import { IFilterImporterOptions } from 'node-sass-magic-importer/src/interfaces/IImporterOptions';
+import { IFilterImporterOptions } from 'node-sass-magic-importer/dist/interfaces/IImporterOptions';
 
 export = function nodeImporter(userOptions?: IFilterImporterOptions) {
   const options = Object.assign({}, defaultOptions, userOptions);

--- a/packages/node-sass-magic-importer/src/default-options.ts
+++ b/packages/node-sass-magic-importer/src/default-options.ts
@@ -1,4 +1,4 @@
-import { ICustomFilter } from 'css-node-extract/src/interfaces/ICustomFilter';
+import { ICustomFilter } from 'css-node-extract/dist/interfaces/ICustomFilter';
 
 export const defaultOptions: {
   cwd: string;

--- a/packages/node-sass-package-importer/src/index.ts
+++ b/packages/node-sass-package-importer/src/index.ts
@@ -4,7 +4,7 @@ import {
 } from 'node-sass-magic-importer/dist/toolbox';
 import { defaultOptions } from './default-options';
 
-import { IPackageImporterOptions } from 'node-sass-magic-importer/src/interfaces/IImporterOptions';
+import { IPackageImporterOptions } from 'node-sass-magic-importer/dist/interfaces/IImporterOptions';
 
 export = function packageImporter(userOptions?: IPackageImporterOptions) {
   const options = Object.assign({}, defaultOptions, userOptions);


### PR DESCRIPTION
I ran into an issue trying to update a project which depends on `node-sass-package-importer` to use TypeScript's project references: 

```
error TS6307: File '<project>/node_modules/node-sass-magic-importer/src/interfaces/IImporterOptions.ts' is not in project file list. Projects must list all files or use an 'include' pattern.
```

Looking at the output of `--traceResolution`, I believe this is happening because a source file file is accidentally being imported instead of the compiled .js/.dts: 

```
======== Resolving module 'node-sass-magic-importer/src/interfaces/IImporterOptions' from '<project>/node_modules/node-sass-package-importer/dist/index.d.ts'. ========
Explicitly specified module resolution kind: 'NodeJs'.
Loading module 'node-sass-magic-importer/src/interfaces/IImporterOptions' from 'node_modules' folder, target file type 'TypeScript'.
Directory '<project>/node_modules/node-sass-package-importer/dist/node_modules' does not exist, skipping all lookups in it.
Directory '<project>/node_modules/node-sass-package-importer/node_modules' does not exist, skipping all lookups in it.
'package.json' does not have a 'typesVersions' field.
Found 'package.json' at '<project>/node_modules/node-sass-magic-importer/package.json'. Package ID is 'node-sass-magic-importer/src/interfaces/IImporterOptions/index.d.ts@5.2.0'.
File '<project>/node_modules/node-sass-magic-importer/src/interfaces/IImporterOptions.ts' exist - use it as a name resolution result.
Resolving real path for '/<project>/node_modules/node-sass-magic-importer/src/interfaces/IImporterOptions.ts', result '<project>/node_modules/node-sass-magic-importer/src/interfaces/IImporterOptions.ts'.
======== Module name 'node-sass-magic-importer/src/interfaces/IImporterOptions' was successfully resolved to '<project>/node_modules/node-sass-magic-importer/src/interfaces/IImporterOptions.ts'. ========
``` 