### PR TITLE
node-sass-glob-importer readme update

### DIFF
--- a/packages/node-sass-glob-importer/README.md
+++ b/packages/node-sass-glob-importer/README.md
@@ -33,28 +33,33 @@ sass.render({
 ```js
 // webpack.config.js
 const globImporter = require('node-sass-glob-importer');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   module: {
     rules: [
       {
         test: /\.scss$/,
-        use: ExtractTextPlugin.extract([
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+          },
           {
             loader: 'css-loader'
           }, {
             loader: 'sass-loader',
             options: {
-              importer: globImporter()
+              sassOptions: {
+                importer: globImporter()
+              }
             }
           }
-        ])
+        ]
       }
     ]
   },
   plugins: [
-    new ExtractTextPlugin({
+    new MiniCssExtractPlugin({
       filename: 'style.css'
     })
   ]


### PR DESCRIPTION
- Replace deprecated ExtractTextPlugin by MiniCssExtractPlugin https://github.com/webpack-contrib/extract-text-webpack-plugin
- Update sass-loader options structure to v8.0.0 https://github.com/webpack-contrib/sass-loader/releases/tag/v8.0.0