### PR TITLE
Used md5 to import scss/css files exactly one time based on their con…

### DIFF
--- a/packages/node-sass-once-importer/package-lock.json
+++ b/packages/node-sass-once-importer/package-lock.json
@@ -32,6 +32,33 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "diff_match_patch": {
+      "version": "0.1.1",
+      "resolved": "http://www.verdaccio.web/diff_match_patch/-/diff_match_patch-0.1.1.tgz",
+      "integrity": "sha1-0/FNW3b7S1qc9EcGJh2ttb2X7bw="
+    },
+    "exceptions": {
+      "version": "0.1.1",
+      "resolved": "http://www.verdaccio.web/exceptions/-/exceptions-0.1.1.tgz",
+      "integrity": "sha1-twOQB5XCjwetadusX2h4b5RWIbI=",
+      "requires": {
+        "formaterrors": "0.1.1"
+      }
+    },
+    "formaterrors": {
+      "version": "0.1.1",
+      "resolved": "http://www.verdaccio.web/formaterrors/-/formaterrors-0.1.1.tgz",
+      "integrity": "sha1-fjZz5HTfeoOXE5KBgpNito/ODes=",
+      "requires": {
+        "diff_match_patch": "0.1.1",
+        "stack-trace": "0.0.6"
+      }
+    },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "http://www.verdaccio.web/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -79,14 +106,16 @@
     },
     "node-sass-magic-importer": {
       "version": "5.3.2",
+      "resolved": "http://www.verdaccio.web/node-sass-magic-importer/-/node-sass-magic-importer-5.3.2.tgz",
+      "integrity": "sha512-T3wTUdUoXQE3QN+EsyPpUXRI1Gj1lEsrySQ9Kzlzi15QGKi+uRa9fmvkcSy2y3BKgoj//7Mt9+s+7p0poMpg6Q==",
       "requires": {
         "css-node-extract": "^2.1.3",
         "css-selector-extract": "^3.3.6",
         "findup-sync": "^3.0.0",
-        "glob": "^7.1.4",
+        "glob": "^7.1.3",
         "object-hash": "^1.3.1",
         "postcss-scss": "^2.0.0",
-        "resolve": "^1.11.0"
+        "resolve": "^1.10.1"
       },
       "dependencies": {
         "@types/events": {
@@ -881,7 +910,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "resolved": "http://www.verdaccio.web/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "lower-case": {
@@ -940,7 +969,8 @@
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "resolved": "",
+          "resolved": "http://www.verdaccio.web/mixin-deep/-/mixin-deep-1.3.1.tgz",
+          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"
@@ -1205,7 +1235,8 @@
         },
         "set-value": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "http://www.verdaccio.web/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -1453,7 +1484,8 @@
         },
         "union-value": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "http://www.verdaccio.web/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "requires": {
             "arr-union": "^3.1.0",
             "get-value": "^2.0.6",
@@ -1556,6 +1588,15 @@
         }
       }
     },
+    "nodejs-md5": {
+      "version": "1.1.0",
+      "resolved": "http://www.verdaccio.web/nodejs-md5/-/nodejs-md5-1.1.0.tgz",
+      "integrity": "sha512-U4oSRfiATjfqBM37c5MBSo7JyLnHcWsD4xvyMUJw4AdPCOg0aMvB40M8H50yvHLMbPokY7HufPPokEJw+AwlpQ==",
+      "requires": {
+        "exceptions": "^0.1.1",
+        "fs": "^0.0.1-security"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1579,6 +1620,11 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.6",
+      "resolved": "http://www.verdaccio.web/stack-trace/-/stack-trace-0.0.6.tgz",
+      "integrity": "sha1-HnGb1qJin/CcGJ4Xqe+QKpT8XbA="
     },
     "typescript": {
       "version": "3.5.1",

--- a/packages/node-sass-once-importer/package.json
+++ b/packages/node-sass-once-importer/package.json
@@ -7,7 +7,7 @@
     "sass",
     "once-importer"
   ],
-  "version": "5.3.2",
+  "version": "5.3.3",
   "author": "Markus Oberlehner",
   "homepage": "https://github.com/maoberlehner/node-sass-magic-importer/tree/master/packages/node-sass-once-importer",
   "license": "MIT",
@@ -26,7 +26,8 @@
     "url": "https://github.com/maoberlehner/node-sass-magic-importer/issues"
   },
   "dependencies": {
-    "node-sass-magic-importer": "^5.3.2"
+    "node-sass-magic-importer": "^5.3.2",
+    "nodejs-md5": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.4",

--- a/packages/node-sass-once-importer/src/index.ts
+++ b/packages/node-sass-once-importer/src/index.ts
@@ -2,20 +2,27 @@ import {
   buildIncludePaths,
   resolveUrl,
 } from 'node-sass-magic-importer/dist/toolbox';
+import { ImporterReturnType, AsyncImporter } from 'node-sass';
+import * as md5 from 'nodejs-md5';
 
 const EMPTY_IMPORT = {
   file: ``,
   contents: ``,
 };
 
-export = function onceImporter() {
-  return function importer(url: string, prev: string) {
+interface NodeSassOnceImporterContext {
+  store: Set<string>
+}
+export = function onceImporter(): AsyncImporter {
+  let nodeSassOnceImporterContext: NodeSassOnceImporterContext;
+
+  return function importer(url: string, prev: string, done: (data: ImporterReturnType) => void) {
     const nodeSassOptions = this.options;
     // Create a context for the current importer run.
     // An importer run is different from an importer instance,
     // one importer instance can spawn infinite importer runs.
-    if (!this.nodeSassOnceImporterContext) {
-      this.nodeSassOnceImporterContext = {
+    if (!nodeSassOnceImporterContext) {
+      nodeSassOnceImporterContext = {
         store: new Set(),
       };
     }
@@ -23,22 +30,41 @@ export = function onceImporter() {
     // Each importer run has it's own new store, otherwise
     // files already imported in a previous importer run
     // would be detected as multiple imports of the same file.
-    const store = this.nodeSassOnceImporterContext.store;
-    const includePaths = buildIncludePaths(
-      nodeSassOptions.includePaths,
-      prev,
-    );
+    const store = nodeSassOnceImporterContext.store;
+
+    let includePaths: Array<string> = [];
+
+    if (nodeSassOptions.includePaths) {
+      for (let path of nodeSassOptions.includePaths) {
+        const paths = buildIncludePaths(path, prev);
+        includePaths = [...includePaths, ...paths];
+      }
+    } else {
+      includePaths = buildIncludePaths('', prev);
+    }
+
     const resolvedUrl = resolveUrl(
       url,
       includePaths,
     );
 
-    if (store.has(resolvedUrl)) {
-      return EMPTY_IMPORT;
+    if (!md5 || !md5.file || !md5.file.quiet) {
+      throw 'MD5 is not present!';
     }
 
-    store.add(resolvedUrl);
+    md5.file.quiet(resolvedUrl, function (err: any, result: string) {
+      if (err) {
+        // fallback to url
+        result = resolvedUrl;
+      }
 
-    return null;
+      if (store.has(result)) {
+        done(EMPTY_IMPORT);
+      } else {
+        store.add(resolvedUrl);
+
+        done({ file: resolvedUrl });
+      }
+    });
   };
 };


### PR DESCRIPTION
Hi

I propose to use md5 generation for importing scss/css file content, instead of just add their URI to nodeSassOnceImporterContext.store.

By creating md5 for content of files that are being imported, we can better make sure that files are imported only once.

I used nodejs-md5 library to generate md5, but any other md5 library can satisfy this need.

Since the API of nodejs-md5 is async, I needed to tamper index.ts a little (added a third callback argument to importer() function), so that it also works asynchronously.

I also propose to use nodeSassOnceImporterContext as an outer variable, instead of using it on 'this'. IMHO this better guarantees that the variable is assigned only once.